### PR TITLE
RF-1.0.1.2.1 - Printing list from local list.txt and prettified the output

### DIFF
--- a/src/main/bash/commands/kobman-list.sh
+++ b/src/main/bash/commands/kobman-list.sh
@@ -2,18 +2,12 @@
 
 function __kob_list {
 
-__kobman_secure_curl "https://raw.githubusercontent.com/$KOBMAN_NAMESPACE/KOBman/master/dist/list.txt" > tmp.txt
-
-# envs="Von-Network,TheOrgBook,greenlight,kobman,KOBConnect,KOBRegistry,KochiOrgBook,KOBDflow,KOBVON"
-__kobman_echo_white "Available environments and their respective version numbers"
+cat $KOBMAN_DIR/var/list.txt > tmp.txt
+__kobman_echo_cyan "Available environments and their respective version numbers"
 __kobman_echo_white "---------------------------------------------------------------"
-# for i in $envs; do
-#     cat tmp.txt | grep "$i" >> tmp1.txt
-# done
-# cat tmp1.txt
 sed 's/,/ /g' tmp.txt > tmp1.txt
 sed 's/,/ /g' tmp.txt | cut -d " " -f 1 > tmp2.txt
 cat tmp1.txt | grep -h -f tmp2.txt > tmp3.txt
 cat tmp3.txt
-rm tmp*
+rm tmp*.txt
 }


### PR DESCRIPTION
- The kob list command now prints from the local list.txt file under .kobman/var/ folder, instead of curling from remote.