### PR TITLE
RF-1.0.1.6.1 : KOB version support for environment

### DIFF
--- a/src/main/bash/commands/kobman-version.sh
+++ b/src/main/bash/commands/kobman-version.sh
@@ -3,7 +3,6 @@
 
 function __kob_version {
 
-
   local environment_parameter=$1
   local environment_value=$2
 

--- a/src/main/bash/commands/kobman-version.sh
+++ b/src/main/bash/commands/kobman-version.sh
@@ -1,15 +1,22 @@
-#!/usr/bin/env bash
-
+#!/bin/bash
 
 function __kob_version {
+
 
   local environment_parameter=$1
   local environment_value=$2
 
   if [ -z "$environment_parameter" ]
-	then
-		echo "KOBman version" "$(cat ${KOBMAN_DIR}/var/version.txt)"
-	else
-		__kobman_version_"$environment_value"
-	fi
+  then
+    echo "KOBman version" "$(cat ${KOBMAN_DIR}/var/version.txt)"
+    return 0
+  fi
+
+  if [[ ! -z $environment_value && -f "${KOBMAN_DIR}/envs/kob_env_${environment_value}/current" ]]
+  then
+                echo "${environment_value} version" "$(cat ${KOBMAN_DIR}/envs/kob_env_${environment_value}/current)"
+  else
+                __kobman_echo_red "$environment_value environment is not installed in the Local system !"
+  fi
+
 }

--- a/tests/commands/test-kob-version.sh
+++ b/tests/commands/test-kob-version.sh
@@ -25,7 +25,7 @@ function __test_kob_init
          __kobman_echo_no_colour "Please re-install and try again"
          __kobman_echo_no_colour "Exiting!!!"
          test_status="failed"
-         exit 
+         exit
     else
          __kobman_echo_no_colour "version file found "
          __kobman_echo_no_colour "Proceeding with the test..."
@@ -45,7 +45,7 @@ function __test_kob_validate
 
     __kobman_echo_no_colour "Validating...."
 
-    cat tmp.txt | grep -qw "KOBman version [0-9].[0-9].[0-9]" 
+    cat tmp.txt | grep -qw "KOBman version [0-9].[0-9].[0-9]"
     if [[ "$?" != "0" ]]; then
         __kobman_echo_no_colour "no version details available"
         test_status="failed"
@@ -61,7 +61,7 @@ function __test_kob_cleanup
 function __test_kob_run
 {
     test_status="success"
-    
+
     __test_kob_init
     __test_kob_execute
     __test_kob_validate


### PR DESCRIPTION
@asa1997 Requesting LGTM for the version support for environment functionality

Please run the version command for the environment & test script for the version command. 

make sure the KOBman directory is under /home/usr
move into the test script directory: KOBman/tests/commands/
execute the following command, ./test-kob-version.sh dummyenv (version can be 0.0.2,0.0.3,0.0.5,0.0.7,0.0.9)
The final output will be,

test-kob-version success, if the test script ran successfully. Or,
test-kob-version failed, if it failed.