### PR TITLE
Test upgrade - Test script for upgrade added

### DIFF
--- a/src/main/bash/commands/kobman-upgrade.sh
+++ b/src/main/bash/commands/kobman-upgrade.sh
@@ -1,29 +1,29 @@
 #!/bin/bash
 function __kob_upgrade {
-mkdir $KOBMAN_DIR/backup
+mkdir $KOBMAN_DIR/bak
 __kobman_echo_white "Making backups..."
-zip -r $KOBMAN_DIR/backup/kobman_backup.zip .kobman
+zip -r $KOBMAN_DIR/bak/kobman_bak.zip .kobman
 __kobman_echo_white "Removing current version..."
-find $KOBMAN_DIR -mindepth 1 -name backup -prune -o -exec rm -rf {} +
+find $KOBMAN_DIR -mindepth 1 -name bak -prune -o -exec rm -rf {} +
 __kobman_echo_white "Fetching latest version..."
 __kobman_secure_curl https://raw.githubusercontent.com/$KOBMAN_NAMESPACE/KOBman/dist/dist/get.kobman.io | bash
-unzip $KOBMAN_DIR/backup/kobman_backup.zip -d $KOBMAN_DIR/backup
+unzip $KOBMAN_DIR/bak/kobman_bak.zip -d $KOBMAN_DIR/bak
 __kobman_echo_white "Restoring user configs..."
-dir=$(find  $KOBMAN_DIR/backup/.kobman/envs -type d -name kob_env_*)
+dir=$(find  $KOBMAN_DIR/bak/.kobman/envs -type d -name kobman-*)
 if [[ -n $dir ]]; then
-    mv $KOBMAN_DIR/backup/.kobman/envs/kob_env_* $KOBMAN_DIR/envs
+    mv $KOBMAN_DIR/bak/.kobman/envs/kobman-* $KOBMAN_DIR/envs
 fi
-if [[ -f $KOBMAN_DIR/backup/.kobman/var/*.proc ]]; then
-    mv $KOBMAN_DIR/backup/.kobman/var/*.proc $KOBMAN_DIR/var/
+if [[ -f $KOBMAN_DIR/bak/.kobman/var/*.proc ]]; then
+    mv $KOBMAN_DIR/bak/.kobman/var/*.proc $KOBMAN_DIR/var/
 fi
-if [[ -f $KOBMAN_DIR/backup/.kobman/var/current ]]; then
-    mv $KOBMAN_DIR/backup/.kobman/var/current $KOBMAN_DIR/var/
+if [[ -f $KOBMAN_DIR/bak/.kobman/var/current ]]; then
+    mv $KOBMAN_DIR/bak/.kobman/var/current $KOBMAN_DIR/var/
 fi
 source $KOBMAN_DIR/bin/kobman-init.sh
 __kobman_echo_blue "Upgraded successfully"
 __kobman_echo_blue "Current version:$(cat $KOBMAN_DIR/var/version.txt)"
 
-rm -rf $KOBMAN_DIR/backup
+rm -rf $KOBMAN_DIR/bak
 
 ##TODO:- validate whether the user configs are compatible with the current version
 }

--- a/tests/commands/test-kob-upgrade.sh
+++ b/tests/commands/test-kob-upgrade.sh
@@ -5,23 +5,51 @@ function __test_kob_init
         echo "kobman not found"
         echo "Please install kobman first and try again"
         exit 1
+    else
+        source $KOBMAN_DIR/bin/kobman-init.sh
+        source $KOBMAN_DIR/src/kobman-utils.sh
+        __kobman_echo_no_colour "kob found"
     fi
 
+    if [[ -z $FAKE_REPO_NAMESPACE ]]; then
+        __kobman_echo_no_colour "No dummy namespace found"
+        __kobman_echo_no_colour "Cannot run test script without fake repository"
+        __kobman_echo_no_colour "Exiting!!!"
+        exit 1
+    fi
 }
 
 function __test_kob_execute
 {
+    __kobman_echo_no_colour "Executing commands"
+    kob -V >> $HOME/old.txt
+    tree $KOBMAN_DIR/envs >> $HOME/tree1.txt
     kob upgrade >> $HOME/output.txt
+    tree $KOBMAN_DIR/envs >> $HOME/tree2.txt
+    kob -V >> $HOME/new.txt
 }
 
 function __test_kob_validate
 {
+    __kobman_echo_no_colour "Validating upgrade command...."
+    diff1=$(comm -3 $HOME/old.txt $HOME/new.txt)
+    if [[ -z $diff1 ]]; then
+        __kobman_echo_no_colour "Version did not change after upgrading"
+        test_status="failed"
+        return 1
+    fi
 
+    diff2=$(comm -3 $HOME/tree1.txt $HOME/tree2.txt)
+    if [[ -n $diff2 ]]; then
+        __kobman_echo_no_colour "User configs were not restored properly"
+        test_status="failed"
+        return 1
+    fi
 }
 
 function __test_kob_cleanup
 {
-    rm $HOME/output.txt
+    rm $HOME/output.txt $HOME/old.txt $HOME/new.txt $HOME/tree1.txt $HOME/tree2.txt
 }
 function __test_kob_run
 {
@@ -30,4 +58,10 @@ function __test_kob_run
     __test_kob_execute
     __test_kob_validate
     __test_kob_cleanup
+    if [[ $test_status == "success" ]]; then
+        __kobman_echo_green "test-kob-update success"
+    else
+        __kobman_echo_red "test-kob-update failed"
+    fi
 }
+__test_kob_run

--- a/tests/commands/test-kob-upgrade.sh
+++ b/tests/commands/test-kob-upgrade.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+function __test_kob_init
+{
+    if [[ ! -d $KOBMAN_DIR ]]; then
+        echo "kobman not found"
+        echo "Please install kobman first and try again"
+        exit 1
+    fi
+
+}
+
+function __test_kob_execute
+{
+    kob upgrade >> $HOME/output.txt
+}
+
+function __test_kob_validate
+{
+
+}
+
+function __test_kob_cleanup
+{
+    rm $HOME/output.txt
+}
+function __test_kob_run
+{
+    test_status="success"
+    __test_kob_init
+    __test_kob_execute
+    __test_kob_validate
+    __test_kob_cleanup
+}

--- a/tests/commands/test-kob-upgrade.sh
+++ b/tests/commands/test-kob-upgrade.sh
@@ -59,9 +59,9 @@ function __test_kob_run
     __test_kob_validate
     __test_kob_cleanup
     if [[ $test_status == "success" ]]; then
-        __kobman_echo_green "test-kob-update success"
+        __kobman_echo_green "test-kob-upgrade success"
     else
-        __kobman_echo_red "test-kob-update failed"
+        __kobman_echo_red "test-kob-upgrade failed"
     fi
 }
 __test_kob_run


### PR DESCRIPTION
Please follow the instructions to run the test script for upgrade,
1. Move into the KOBman directory in your system and run the following scripts.
   - `export KOBMAN_NAMESPACE=<your_namespace>` (substitute <your_namespace> with your namespace)
   - `./bin/release.sh tagx` (x - any number to represent the version)
   - `./bin/dopublish.sh tagx` (same tag as above)
2. Set the namespace env variable back to hyperledgerkochi
    `export KOBMAN_NAMESPACE=hyperledgerkochi`
3. Go to your terminal window and run the following command substituting <your_namespace> to export your namespace value.
     `export FAKE_REPO_NAMESPACE=<your_namespace>`
4. Move out to the home directory by running `cd` command.
5. Run the following command to run the test script for upgrade,
    `./KOBman/tests/commands/test-kob-upgrade.sh`

OUTPUT
------------
Success condition:-
![image](https://user-images.githubusercontent.com/58501088/86918492-6e425800-c144-11ea-8841-7a5b7381e5e2.png)

Executing the command again without a new release would fail the test script as the version will not change even after upgrading.

Failing condition:-
![image](https://user-images.githubusercontent.com/58501088/86918761-beb9b580-c144-11ea-9d0c-51099013bd99.png)


After testing remove the env variable FAKE_REPO_NAMESPACE.
  `unset FAKE_REPO_NAMESPACE`